### PR TITLE
fix: TokenBucket 부동소수점 정밀도 손실 해결

### DIFF
--- a/src/main/java/com/example/ratelimiter/domain/strategy/TokenBucketStrategy.java
+++ b/src/main/java/com/example/ratelimiter/domain/strategy/TokenBucketStrategy.java
@@ -76,11 +76,9 @@ public class TokenBucketStrategy implements RateLimitStrategy {
                 new_tokens = filled_tokens - requested
             end
 
-            -- 상태 업데이트
-            redis.call("SETEX", tokens_key, ttl, new_tokens)
-            redis.call("SETEX", timestamp_key, ttl, now)
-
-            -- Issue #3: tostring()으로 부동소수점 정밀도 보존
+            -- Issue #3: tostring()으로 부동소수점 정밀도 보존 (저장 + 반환)
+            redis.call("SETEX", tokens_key, ttl, tostring(new_tokens))
+            redis.call("SETEX", timestamp_key, ttl, tostring(now))
             return {
                 allowed and 1 or 0,
                 tostring(new_tokens),

--- a/src/main/java/com/example/ratelimiter/infrastructure/redis/RedisScriptExecutor.java
+++ b/src/main/java/com/example/ratelimiter/infrastructure/redis/RedisScriptExecutor.java
@@ -20,7 +20,20 @@ public interface RedisScriptExecutor {
      * @return 실행 결과
      */
     List<Long> executeLuaScript(String script, List<String> keys, List<String> args);
-    
+
+    /**
+     * Lua 스크립트를 실행하고 원시 타입(Long/String 혼합) 결과 반환
+     *
+     * Lua에서 숫자는 Long, tostring()은 String으로 반환되므로
+     * 부동소수점 정밀도가 필요한 경우 이 메서드를 사용한다.
+     *
+     * @param script Lua 스크립트
+     * @param keys Redis 키 목록
+     * @param args 스크립트 인자 목록
+     * @return Long/String 혼합 결과 리스트
+     */
+    List<Object> executeRawLuaScript(String script, List<String> keys, List<String> args);
+
     /**
      * 키 삭제
      * 

--- a/src/test/java/com/example/ratelimiter/infrastructure/redis/RedisIntegrationTest.java
+++ b/src/test/java/com/example/ratelimiter/infrastructure/redis/RedisIntegrationTest.java
@@ -170,6 +170,54 @@ class RedisIntegrationTest {
     }
 
     @Test
+    @DisplayName("executeRawLuaScript - Long/String 혼합 타입 반환")
+    void executeRawLuaScriptTest() {
+        // given - 숫자와 tostring() 문자열을 혼합 반환하는 Lua 스크립트
+        String script = """
+                return {1, tostring(3.14159265358979), 42}
+                """;
+
+        // when
+        List<Object> result = scriptExecutor.executeRawLuaScript(
+                script, List.of(), List.of()
+        );
+
+        // then
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0)).isInstanceOf(Long.class);
+        assertThat((Long) result.get(0)).isEqualTo(1L);
+        assertThat(result.get(1)).isInstanceOf(String.class);
+        assertThat(Double.parseDouble((String) result.get(1))).isCloseTo(3.14159265358979, within(1e-10));
+        assertThat(result.get(2)).isInstanceOf(Long.class);
+        assertThat((Long) result.get(2)).isEqualTo(42L);
+    }
+
+    @Test
+    @DisplayName("tostring()으로 소수점 3자리 이하 정밀도 보존 확인")
+    void tostringPrecisionPreservationTest() {
+        // given - 구 방식 math.floor(x * 100) / 100 에서 0으로 절삭되는 값
+        // 0.000001 * 100 = 0.0001 → math.floor → 0 → 정밀도 손실
+        // tostring(0.000001) → "1e-06" → 정밀도 보존
+        String script = """
+                local tiny = 0.000001
+                local old_way = math.floor(tiny * 100)
+                return {old_way, tostring(tiny)}
+                """;
+
+        // when
+        List<Object> result = scriptExecutor.executeRawLuaScript(
+                script, List.of(), List.of()
+        );
+
+        // then
+        long oldWay = (Long) result.get(0);
+        double newWay = Double.parseDouble((String) result.get(1));
+
+        assertThat(oldWay).isZero();              // 구 방식: 정밀도 손실
+        assertThat(newWay).isEqualTo(0.000001);   // 신 방식: 정밀도 보존
+    }
+
+    @Test
     @DisplayName("스크립트 캐싱 확인 - 동일 스크립트 여러 번 실행")
     void scriptCachingTest() {
         // given


### PR DESCRIPTION
## Summary
- Lua `math.floor(x * 100) / 100` 방식의 소수점 2자리 정밀도 제한을 `tostring()` 문자열 반환으로 대체
- `RedisScriptExecutor`에 `executeRawLuaScript` 메서드 추가 (Long/String 혼합 타입 지원)
- `executeLuaScript`가 `executeRawLuaScript`를 위임 호출하도록 리팩터링하여 중복 제거

## Changes
| 파일 | 변경 내용 |
|---|---|
| `RedisScriptExecutor.java` | `executeRawLuaScript()` 인터페이스 메서드 추가 |
| `RedisScriptExecutorImpl.java` | `executeRawLuaScript()` 구현, `executeLuaScript` 위임 호출로 DRY 개선 |
| `TokenBucketStrategy.java` | `DECIMAL_PRECISION` 제거, Lua `tostring()` + `Double.parseDouble()` 전환 |
| `RedisIntegrationTest.java` | Raw 스크립트 혼합 타입 테스트, 정밀도 보존 비교 테스트 추가 |

## Why
`DECIMAL_PRECISION = 100`으로 `math.floor(new_tokens * 100)`을 사용하면 소수점 3자리 이하가 절삭된다.
예: `0.000001 * 100 = 0.0001 → math.floor → 0` (정밀도 손실)

Redis Lua는 숫자를 정수(Long)로만 반환하므로, `tostring()`으로 문자열 변환 후 Java에서 `Double.parseDouble()`로 복원하면 정밀도 제한 자체가 제거된다.

## Test plan
- [x] 기존 TokenBucket 통합 테스트 통과
- [x] `executeRawLuaScript` Long/String 혼합 타입 반환 검증
- [x] `tostring()` vs `math.floor(x * 100)` 정밀도 보존 비교 테스트
- [x] 다른 전략(FixedWindow, SlidingWindow, LeakyBucket) 테스트 영향 없음

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)